### PR TITLE
Added Integration Helper Methods

### DIFF
--- a/kolsol/utils/integrate.py
+++ b/kolsol/utils/integrate.py
@@ -1,0 +1,55 @@
+from typing import Callable
+
+from .types import TypeTensor
+
+
+def euler_step(fn: Callable[[TypeTensor], TypeTensor], dt: float) -> Callable[[TypeTensor], TypeTensor]:
+
+    """Calculate integration step using Euler's method.
+
+    Parameters
+    ----------
+    fn: Callable[[TypeTensor], TypeTensor]
+        Function to calculate the derivative.
+    dt: float
+        Time-step size.
+
+    Returns
+    -------
+    Callable[[TypeTensor], TypeTensor]
+        Function to calculate integration step.
+    """
+
+    def _euler(field: TypeTensor) -> TypeTensor:
+        return dt * fn(field)
+
+    return _euler
+
+
+def rk4_step(fn: Callable[[TypeTensor], TypeTensor], dt: float) -> Callable[[TypeTensor], TypeTensor]:
+
+    """Calculate integration step using RK4 method.
+
+    Parameters
+    ----------
+    fn: Callable[[TypeTensor], TypeTensor]
+        Function to calculate the derivative.
+    dt: float
+        Time-step size.
+
+    Returns
+    -------
+    Callable[[TypeTensor], TypeTensor]
+        Function to calculate integration step.
+    """
+
+    def _rk4(field: TypeTensor) -> TypeTensor:
+
+        k1 = fn(field)
+        k2 = fn(field + 0.5 * k1 * dt)
+        k3 = fn(field + 0.5 * k2 * dt)
+        k4 = fn(field + 1.0 * k3 * dt)
+
+        return dt * (k1 + 2.0 * k2 + 2.0 * k3 + k4) / 6.0
+
+    return _rk4

--- a/kolsol/utils/types.py
+++ b/kolsol/utils/types.py
@@ -1,0 +1,6 @@
+from typing import Union
+
+import numpy as np
+import torch
+
+TypeTensor = Union[np.array, torch.Tensor]


### PR DESCRIPTION
Added method to integrate using Euler/RK4 methods. These functions will return a function that calculates the stepsize.

Example:

```python
integrator = rk4_step(fn=ks.dynamics, dt=0.01)
field += integrator(field)
```

Resolves: #6
