### PR TITLE
Fixed device mismatch in energy_spectrum computation

### DIFF
--- a/kolsol/torch/solver.py
+++ b/kolsol/torch/solver.py
@@ -405,7 +405,7 @@ class KolSol(BaseTorchKolSol):
         uu = 0.5 * oe.contract('...u -> ...', u_hat * torch.conj(u_hat)).real
         intk = torch.sqrt(self.kk).to(torch.int)
 
-        ek = torch.zeros((tuple([*leading_dims]) + tuple([torch.max(intk) + 1])))
+        ek = torch.zeros((tuple([*leading_dims]) + tuple([torch.max(intk) + 1])), device=self.device)
         for combo in it.product(*map(range, intk.shape)):
             ek[tuple([...]) + tuple([intk[combo]])] += uu[tuple([...]) + tuple(combo)] / self.nk_grid ** self.ndim
 


### PR DESCRIPTION
I addressed the device mismatch issue by specifying the device type in the `torch.zeros` call within the energy spectrum computation, see below:

```python
# Before the change
torch.zeros((tuple([*leading_dims]) + tuple([torch.max(intk) + 1])))

# After the change
torch.zeros((tuple([*leading_dims]) + tuple([torch.max(intk) + 1])), device=self.device)


